### PR TITLE
Bumb Grocy from 4.4.2 to 4.5.0

### DIFF
--- a/grocy/Dockerfile
+++ b/grocy/Dockerfile
@@ -6,7 +6,7 @@ FROM ${BUILD_FROM}
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Setup base
-ARG GROCY_VERSION="v4.4.2"
+ARG GROCY_VERSION="v4.5.0"
 # hadolint ignore=DL3003
 RUN \
     apk add --no-cache \


### PR DESCRIPTION
Bumps to using Grocy version 4.5.0, which includes some fixes for the UI in Home Assistant iframe.

# Proposed Changes

> (Describe the changes and rationale behind them)

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
